### PR TITLE
[#138] 카카오맵 최대 13레벨까지만 맵 축소 제한

### DIFF
--- a/src/components/stampMap/KakaoMap.tsx
+++ b/src/components/stampMap/KakaoMap.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { Map, Polygon } from 'react-kakao-maps-sdk';
 import { MAP_COLOR, MAP_COLOR_INDEX } from '@/constants/mapColor';
 import ReSetttingMapBounds from '@/components/stampMap/ReSetttingMapBounds';
@@ -10,6 +8,7 @@ import KakaoMapMarker from './KakaoMapMarker';
 import useKakaoMap from '@/hooks/useKakaoMap';
 import StampModal from '../common/Modal/StampModal';
 import useModal from '@/hooks/useModal';
+import KakaoMapMaxLevel from './KakaoMapMaxLevel';
 
 const KakaoMap = () => {
   const { geoList, location, activeIndex, selectedPath, filteredStamps, updateHoverState, updatePolygonPath } =
@@ -61,6 +60,7 @@ const KakaoMap = () => {
 
         {filteredStamps?.map((stamp) => <KakaoMapMarker key={stamp.id} stamp={stamp} openModal={openModal} />)}
         <ReSetttingMapBounds paths={selectedPath} activeIndex={activeIndex} />
+        <KakaoMapMaxLevel />
       </Map>
       <StampModal Modal={Modal} />
       <MapButtonSwiper />

--- a/src/components/stampMap/KakaoMapMaxLevel.tsx
+++ b/src/components/stampMap/KakaoMapMaxLevel.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useMap } from 'react-kakao-maps-sdk';
+
+const KakaoMapMaxLevel = () => {
+  const map = useMap();
+
+  useEffect(() => {
+    // 최대 확대 수준 설정 (13로 설정)
+    if (map) {
+      map.setMaxLevel(13);
+    }
+  }, [map]);
+
+  return null;
+};
+
+export default KakaoMapMaxLevel;

--- a/src/components/stampMap/MapButtonSwiper.tsx
+++ b/src/components/stampMap/MapButtonSwiper.tsx
@@ -21,8 +21,6 @@ const MapButtonSwiper = () => {
     }
   }, [activeIndex]);
 
-  console.log(siDoName);
-
   return (
     <div className="swiperWrapper">
       <div className="ml-[10px] flex items-center justify-center">


### PR DESCRIPTION
## ✅ 이슈 번호

- clsode #138 

## 📌 작업 사항

- 카카오맵 최대 축소 13레벨까지 설정
